### PR TITLE
Follow semver practice for initial version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= functionName %>",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "<%= functionDescription %>",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
The initial version number of a project following semver guidelines should be 0.1.0 http://semver.org/ see:FAQ
